### PR TITLE
Fix trust issue in SSH verifier and add test cases

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -43,8 +43,8 @@ jobs:
     - name: Run tests
       run: go test -v ./...
 
-    # - name: Build executable
-    #   run: go build -o myapp ./cmd/myapp/main.go
+    - name: Build private key verifier executable
+      run: go build -o ssh-privatekey-verifier ./cmd/ssh-privatekey-verifier/main.go
 
     # - name: Publish artifacts
     #   run: |

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 # Go workspace file
 go.work
+
+ssh-privatekey-verifier

--- a/cmd/ssh-privatekey-verifier/main.go
+++ b/cmd/ssh-privatekey-verifier/main.go
@@ -3,19 +3,21 @@ package main
 import (
 	"flag"
 	"fmt"
-	"golang.org/x/crypto/ssh"
 	"lilidap/internal/sshclient"
+
+	"golang.org/x/crypto/ssh"
 )
 
 func main() {
 	host := flag.String("host", "127.0.0.1", "SSH server host")
 	port := flag.Int("port", 22, "SSH server port")
-	keyString := flag.String("key", "", "Path to the public key file")
+	keyString := flag.String("key", "", "The public key text, e.g. 'ssh-rsa AAAAB3Nz...'")
+	debug := flag.Bool("debug", false, "Whether to print debug info aimed at the developer")
 
 	flag.Parse()
 
 	if *keyString == "" {
-		fmt.Println("Please provide a valid public key path using the -key flag.")
+		fmt.Println("Please provide a valid public key using the -key flag.")
 		return
 	}
 
@@ -28,15 +30,19 @@ func main() {
 
 	// Use sshclient to validate server's key
 	// Note: You'll need to implement the ValidateServerKey function or similar in your sshclient package.
-	valid, err := sshclient.ValidateServerPublicKey(*host, *port, sshPublicKey, func(msg string) {})
+	valid, err := sshclient.ValidateServerPublicKey(*host, *port, sshPublicKey, func(msg string) {
+		if *debug {
+			fmt.Println(msg)
+		}
+	})
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
 	}
 
 	if valid {
-		fmt.Println("SSH server's key is valid.")
+		fmt.Println("SSH server proved ownership of the private key.")
 	} else {
-		fmt.Println("SSH server's key is invalid.")
+		fmt.Println("SSH server failed to prove ownership of the private key.")
 	}
 }

--- a/internal/sshclient/sshclient_test.go
+++ b/internal/sshclient/sshclient_test.go
@@ -10,11 +10,22 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"golang.org/x/crypto/ssh"
 )
 
 const serverAddress = "localhost"
+
+type ValidationResponse struct {
+	HasError bool
+	ErrorMsg string
+	Success  bool
+}
+
+type MaybeAcceptableConfig struct {
+	Config      ssh.ServerConfig
+	WhenValid   ValidationResponse
+	WhenInvalid ValidationResponse
+}
 
 func generateKeys() (ssh.Signer, ssh.PublicKey, error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
@@ -58,12 +69,8 @@ func waitForPort(t *testing.T, port int) {
 	}
 }
 
-func startMockSSHServer(t *testing.T, privateKey ssh.Signer, port int) (net.Listener, error) {
+func startMockSSHServer(t *testing.T, config *ssh.ServerConfig, port int, privateKey ssh.Signer) (net.Listener, error) {
 	log := func(line string) { t.Logf("StartMockSSHServer: %s", line) }
-
-	config := &ssh.ServerConfig{
-		NoClientAuth: true,
-	}
 
 	config.AddHostKey(privateKey)
 
@@ -112,7 +119,7 @@ func startMockSSHServer(t *testing.T, privateKey ssh.Signer, port int) (net.List
 	return listener, nil
 }
 
-func WithServer(t *testing.T, body func(ssh.PublicKey, int)) {
+func WithServer(t *testing.T, config *ssh.ServerConfig, body func(ssh.PublicKey, int)) {
 	t.Log("WithServer begins")
 	privateKey, pubKey, err := generateKeys()
 	if err != nil {
@@ -127,7 +134,7 @@ func WithServer(t *testing.T, body func(ssh.PublicKey, int)) {
 	t.Logf("Using port: %d", port)
 
 	t.Log("Starting server")
-	listener, err := startMockSSHServer(t, privateKey, port)
+	listener, err := startMockSSHServer(t, config, port, privateKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,8 +147,8 @@ func WithServer(t *testing.T, body func(ssh.PublicKey, int)) {
 	body(pubKey, port)
 }
 
-func TestSSHServer(t *testing.T) {
-	WithServer(t, func(pubKey ssh.PublicKey, port int) {
+func TryOneSSHServer(t *testing.T, config *ssh.ServerConfig) {
+	WithServer(t, config, func(pubKey ssh.PublicKey, port int) {
 		pubKeyStr := string(ssh.MarshalAuthorizedKey(pubKey)) // e.g. "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAEQCvhlzUS+GjQzqkJcxPa0Hr\n"
 
 		// just check that the key is reasonable
@@ -150,14 +157,136 @@ func TestSSHServer(t *testing.T) {
 	})
 }
 
-func TestSSHClient(t *testing.T) {
-	WithServer(t, func(pubKey ssh.PublicKey, port int) {
-		t.Log("TestSSHClient: in body")
-		isValid, err := ValidateServerPublicKey(serverAddress, port, pubKey, func(msg string) { t.Log(msg) })
-		if err != nil {
-			t.Fatal(err)
-		}
-		require.True(t, isValid)
+func TryOneSSHClient(t *testing.T, mac MaybeAcceptableConfig) {
 
+	_, wrongPubKey, err := generateKeys()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doValidation := func(port int, expectedValid bool, keyToUse ssh.PublicKey) {
+		actualValidity, err := ValidateServerPublicKey(serverAddress, port, keyToUse, func(msg string) { t.Log(msg) })
+		var criteria ValidationResponse
+		var keyLabel string
+		if expectedValid {
+			keyLabel = "correct"
+			criteria = mac.WhenValid
+		} else {
+			keyLabel = "incorrect"
+			criteria = mac.WhenInvalid
+		}
+		t.Logf("Validing the %s key got result: %t", keyLabel, actualValidity)
+
+		if criteria.HasError {
+			require.NotNil(t, err)
+			t.Logf("We expected an error and got one.  Now checking if '%s' = '%s'", criteria.ErrorMsg, err.Error())
+			require.Equal(t, criteria.ErrorMsg, err.Error())
+		} else {
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("We expected no error and didn't get one.  Now checking if %t = %t", criteria.Success, actualValidity)
+			require.Equal(t, criteria.Success, actualValidity)
+		}
+	}
+
+	WithServer(t, &mac.Config, func(pubKey ssh.PublicKey, port int) {
+		doValidation(port, true, pubKey)
+		doValidation(port, false, wrongPubKey)
 	})
+}
+
+var serverConfigs = map[string]MaybeAcceptableConfig{
+	// bad server config: they let the client connect without auth
+	"NoClientAuth": {
+		Config: ssh.ServerConfig{
+			NoClientAuth: true,
+			MaxAuthTries: 1,
+		},
+		WhenValid: ValidationResponse{
+			HasError: true,
+			ErrorMsg: "connection succeeded illegally",
+			Success:  false,
+		},
+		WhenInvalid: ValidationResponse{
+			HasError: false,
+			ErrorMsg: "",
+			Success:  false,
+		},
+	},
+	// bad server config: they require auth but don't accept any methods
+	"NoMethods": {
+		Config: ssh.ServerConfig{
+			NoClientAuth: false,
+			MaxAuthTries: 1,
+		},
+		WhenValid: ValidationResponse{
+			HasError: true,
+			ErrorMsg: "server may not be accepting auth methods",
+			Success:  true,
+		},
+		WhenInvalid: ValidationResponse{
+			HasError: true,
+			ErrorMsg: "server may not be accepting auth methods",
+			Success:  false,
+		},
+	},
+	// good config: can accept password (which we don't attempt to supply)
+	"AuthPassword": {
+		Config: ssh.ServerConfig{
+			NoClientAuth: false,
+			MaxAuthTries: 1,
+			PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
+				return nil, fmt.Errorf("password rejected for %q", c.User()) // Reject all password authentication attempts.
+			},
+		},
+		WhenValid: ValidationResponse{
+			HasError: false,
+			ErrorMsg: "",
+			Success:  true,
+		},
+		WhenInvalid: ValidationResponse{
+			HasError: false,
+			ErrorMsg: "",
+			Success:  false,
+		},
+	},
+	// good config: can accept public key (which we don't attempt to supply)
+	"AuthPublicKey": {
+		Config: ssh.ServerConfig{
+			NoClientAuth: false,
+			MaxAuthTries: 1,
+			PublicKeyCallback: func(c ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+				return nil, fmt.Errorf("public key rejected for %q", c.User()) // Reject all public key authentication attempts.
+			},
+		},
+		WhenValid: ValidationResponse{
+			HasError: false,
+			ErrorMsg: "",
+			Success:  true,
+		},
+		WhenInvalid: ValidationResponse{
+			HasError: false,
+			ErrorMsg: "",
+			Success:  false,
+		},
+	},
+}
+
+func TestSSHServers(t *testing.T) {
+	for configName, possibleConfig := range serverConfigs {
+		t.Run(configName, func(t *testing.T) {
+			pcc := &possibleConfig.Config
+			TryOneSSHServer(t, pcc)
+		})
+	}
+}
+
+func TestSSHClients(t *testing.T) {
+	for configName, possibleConfig := range serverConfigs {
+		t.Run(configName, func(t *testing.T) {
+			pc := possibleConfig
+			TryOneSSHClient(t, pc)
+		})
+	}
 }


### PR DESCRIPTION
* Don't rely on diffie-hellman to tell us whether the key is valid; require the handshake to progress to the auth methods point so that we know the server has answered the decrypt-random-data challenge
* Build the SSH client verifier binary